### PR TITLE
router: add path-params extraction; middleware: add LoggerMiddleware …

### DIFF
--- a/.github/PR_BODY.md
+++ b/.github/PR_BODY.md
@@ -1,0 +1,20 @@
+Title: router: add path-params extraction; middleware improvements
+
+Description:
+This PR implements minimal path-parameter extraction without adding third-party dependencies, and improves middleware logging and API compatibility.
+
+Changes included:
+- Add shttp/pathparams.go with helpers: SetPathValues, SetPathValue, PathValue, extractPathParams.
+- Update shttp/router.go to inject path params into the request context for route patterns using {param}.
+- Add LoggerMiddleware(logger) and update LoggingMiddleware(logger) to accept an optional logger and emit structured [http.request] / [http.response] logs including request_id, user_id, client_ip, status, duration_ms, and error when present.
+- Update tests and examples to use the new helpers.
+- Add GitHub Actions workflow .github/workflows/ci.yml to run tests for both slogr and shttp modules on push and PRs.
+
+Notes:
+- Path extraction uses simple segment-by-segment matching; named tokens must be full path segments (for example /users/{id}). No wildcard/regex support yet to keep the implementation small and dependency-free.
+- Tests: ran go test ./... -v locally; all tests passed.
+
+Follow-ups:
+- Extend path pattern support if desired (wildcards/optional segments).
+- Add a short README usage example showing PathValue usage.
+- Add an integration test that starts the server on port 0 to exercise middleware end-to-end.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,13 @@ jobs:
       - name: Run shttp tests
         working-directory: ./shttp
         run: |
+          # If shttp/go.mod uses a local replace to ../slogr during development,
+          # clone the slogr repository into the parent directory so the replace
+          # path resolves on the runner.
+          if [ -f go.mod ]; then
+            # attempt to detect a replace to ../slogr and clone if present
+            if grep -q "replace .*=> ../slogr" go.mod 2>/dev/null; then
+              git clone https://github.com/andres-vara/slogr ../slogr || true
+            fi
+          fi
           go test ./... -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           go test ./... -v
 
       - name: Run shttp tests
-        working-directory: ./shttp
         run: |
           # If shttp/go.mod uses a local replace to ../slogr during development,
           # ensure the slogr repo is present in the parent directory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,20 +29,26 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Run slogr tests
-        working-directory: ./slogr
+        # Ensure slogr is available in the runner workspace. Clone into the
+        # parent directory (../slogr) so shttp's local replace (../slogr) will
+        # resolve, and run the slogr test suite from there.
         run: |
+          if [ ! -d ../slogr ]; then
+            git clone https://github.com/andres-vara/slogr ../slogr
+          fi
+          cd ../slogr
           go test ./... -v
 
       - name: Run shttp tests
         working-directory: ./shttp
         run: |
           # If shttp/go.mod uses a local replace to ../slogr during development,
-          # clone the slogr repository into the parent directory so the replace
-          # path resolves on the runner.
+          # ensure the slogr repo is present in the parent directory.
           if [ -f go.mod ]; then
-            # attempt to detect a replace to ../slogr and clone if present
             if grep -q "replace .*=> ../slogr" go.mod 2>/dev/null; then
-              git clone https://github.com/andres-vara/slogr ../slogr || true
+              if [ ! -d ../slogr ]; then
+                git clone https://github.com/andres-vara/slogr ../slogr || true
+              fi
             fi
           fi
           go test ./... -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, feature/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+
+      - name: Cache modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run slogr tests
+        working-directory: ./slogr
+        run: |
+          go test ./... -v
+
+      - name: Run shttp tests
+        working-directory: ./shttp
+        run: |
+          go test ./... -v

--- a/error.go
+++ b/error.go
@@ -2,7 +2,7 @@ package shttp
 
 // HTTPError represents an HTTP error with a message and status code
 type HTTPError struct {
-	Message string
+	Message    string
 	StatusCode int
 }
 
@@ -18,4 +18,3 @@ func NewHTTPError(statusCode int, message string) error {
 		StatusCode: statusCode,
 	}
 }
-

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -83,7 +83,7 @@ func healthCheckHandler(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 // userHandler demonstrates accessing path parameters from the URL
 func userHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	userID := r.PathValue("id")
+	userID := shttp.PathValue(r, "id")
 
 	// Debug information
 	w.Header().Set("Content-Type", "text/plain")
@@ -104,7 +104,7 @@ func userHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) er
 
 // testHandler is a test route for debugging path parameters
 func testHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	param1 := r.PathValue("param1")
+	param1 := shttp.PathValue(r, "param1")
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)

--- a/examples/error-handling/main.go
+++ b/examples/error-handling/main.go
@@ -91,7 +91,6 @@ func main() {
 		log.Fatalf("Server shutdown failed: %v", err)
 	}
 
-
 	log.Println("Server gracefully stopped")
 }
 
@@ -151,4 +150,4 @@ func unauthorizedHandler(ctx context.Context, w http.ResponseWriter, r *http.Req
 
 func serverErrorHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	return errors.New("unexpected internal server error occurred")
-} 
+}

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -99,7 +99,7 @@ func homeHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) er
 	// Write response
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	
+
 	html := `
 	<html>
 	<head><title>Logger Example</title></head>
@@ -118,7 +118,7 @@ func homeHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) er
 	</body>
 	</html>
 	`
-	
+
 	fmt.Fprintf(w, html, requestID, userID, clientIP)
 	return nil
 }
@@ -131,7 +131,7 @@ func debugLogHandler(ctx context.Context, w http.ResponseWriter, r *http.Request
 	}
 
 	logger.Debug(ctx, "This is a debug message - useful for detailed troubleshooting")
-	
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, "Debug log entry created - check server logs")
@@ -146,7 +146,7 @@ func infoLogHandler(ctx context.Context, w http.ResponseWriter, r *http.Request)
 	}
 
 	logger.Info(ctx, "This is an info message - for normal operational information")
-	
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, "Info log entry created - check server logs")
@@ -161,9 +161,9 @@ func errorLogHandler(ctx context.Context, w http.ResponseWriter, r *http.Request
 	}
 
 	logger.Error(ctx, "This is an error message - something went wrong")
-	
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintln(w, "Error log entry created - check server logs")
 	return nil
-} 
+}

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -38,19 +38,19 @@ func main() {
 	// Add middleware to the server
 	// 1. Request ID middleware adds a unique ID to each request
 	server.Use(shttp.RequestIDMiddleware())
-	
+
 	// 2. Recovery middleware catches panics in handlers
 	server.Use(shttp.RecoveryMiddleware(logger))
-	
+
 	// 3. Logging middleware logs request details
 	server.Use(shttp.LoggingMiddleware(logger))
-	
+
 	// 4. CORS middleware for cross-origin requests
 	server.Use(shttp.CORSMiddleware([]string{"*"}))
-	
+
 	// 5. Timeout middleware sets a timeout for request processing
 	server.Use(shttp.TimeoutMiddleware(5 * time.Second))
-	
+
 	// 6. Custom middleware
 	server.Use(customHeaderMiddleware("X-Server", "shttp-example"))
 
@@ -90,7 +90,7 @@ func main() {
 // helloWorldHandler returns a simple hello world message
 func helloWorldHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	requestID := shttp.GetRequestID(ctx)
-	
+
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, "Hello, World! (Request ID: %s)\n", requestID)
@@ -123,4 +123,4 @@ func customHeaderMiddleware(headerName, headerValue string) shttp.Middleware {
 			return next(ctx, w, r)
 		}
 	}
-} 
+}

--- a/examples/multi-provider/main.go
+++ b/examples/multi-provider/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "log"
-    "net/http"
-    "os"
-    "os/signal"
-    "syscall"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
-    "github.com/andres-vara/shttp"
-    "github.com/andres-vara/slogr"
+	"github.com/andres-vara/shttp"
+	"github.com/andres-vara/slogr"
 )
 
 func main() {
@@ -23,22 +23,23 @@ func main() {
 	logger := slogr.New(os.Stdout, slogr.DefaultOptions())
 
 	// Create a new server with default configuration
-    server := shttp.New(ctx, nil)
+	server := shttp.New(ctx, nil)
 
-    // Middlewares: request ID, contextual logger, request logging, recovery
-    server.Use(
-        shttp.RequestIDMiddleware(),
-        shttp.ContextualLogger(logger),
-        shttp.LoggingMiddleware(),
-        shttp.RecoveryMiddleware(logger),
-    )
+	// Middlewares: request ID, contextual logger, request logging, recovery
+	server.Use(
+		shttp.RequestIDMiddleware(),
+		shttp.ContextualLogger(logger),
+		shttp.LoggerMiddleware(logger),
+		shttp.LoggingMiddleware(logger),
+		shttp.RecoveryMiddleware(logger),
+	)
 
-    providers := map[string]Provider{
-        "prv1": NewProvider1(),
-        "prv2": NewProvider2(),
-    }
-    app := NewApp(providers)
-    addRoutes(server, app)
+	providers := map[string]Provider{
+		"prv1": NewProvider1(),
+		"prv2": NewProvider2(),
+	}
+	app := NewApp(providers)
+	addRoutes(server, app)
 
 	// Set up a channel to handle shutdown signals
 	done := make(chan os.Signal, 1)
@@ -65,99 +66,103 @@ func main() {
 		log.Fatalf("Server shutdown failed: %v", err)
 	}
 
-    log.Println("Server gracefully stopped")
+	log.Println("Server gracefully stopped")
 }
 
 // addRoutes registers provider-agnostic routes. The provider name is a path
 // parameter, so handlers can resolve the implementation dynamically.
 func addRoutes(server *shttp.Server, app *App) {
-    // POST   /providers/{provider}/users
-    server.POST("/providers/{provider}/users", app.withProvider(app.handleCreateUser))
-    // PUT    /providers/{provider}/users/{id}
-    server.PUT("/providers/{provider}/users/{id}", app.withProvider(app.handleUpdateUser))
-    // DELETE /providers/{provider}/users/{id}
-    server.DELETE("/providers/{provider}/users/{id}", app.withProvider(app.handleDeleteUser))
+	// POST   /providers/{provider}/users
+	server.POST("/providers/{provider}/users", app.withProvider(app.handleCreateUser))
+	// PUT    /providers/{provider}/users/{id}
+	server.PUT("/providers/{provider}/users/{id}", app.withProvider(app.handleUpdateUser))
+	// DELETE /providers/{provider}/users/{id}
+	server.DELETE("/providers/{provider}/users/{id}", app.withProvider(app.handleDeleteUser))
 }
 
 // App holds the provider registry and exposes handlers.
 type App struct {
-    providers map[string]Provider
+	providers map[string]Provider
 }
 
 func NewApp(providers map[string]Provider) *App {
-    return &App{providers: providers}
+	return &App{providers: providers}
 }
 
 // withProvider abstracts provider resolution to avoid repeating handler logic
 // across routes. It reads `{provider}` from the path and injects the resolved
 // Provider into the given function.
 func (a *App) withProvider(fn func(p Provider, ctx context.Context, w http.ResponseWriter, r *http.Request) error) shttp.Handler {
-    return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-        name := r.PathValue("provider")
-        p, ok := a.providers[name]
-        if !ok {
-            return shttp.NewHTTPError(http.StatusNotFound, fmt.Sprintf("unknown provider: %s", name))
-        }
-        return fn(p, ctx, w, r)
-    }
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		name := shttp.PathValue(r, "provider")
+		p, ok := a.providers[name]
+		if !ok {
+			return shttp.NewHTTPError(http.StatusNotFound, fmt.Sprintf("unknown provider: %s", name))
+		}
+		return fn(p, ctx, w, r)
+	}
 }
 
 // handleCreateUser handles user creation for any provider.
 func (a *App) handleCreateUser(p Provider, ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-    var in User
-    if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-        return shttp.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
-    }
-    created, err := p.CreateUser(in)
-    if err != nil {
-        return err
-    }
-    w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(http.StatusCreated)
-    return json.NewEncoder(w).Encode(created)
+	l := shttp.GetLogger(ctx)
+	var in User
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		return shttp.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
+	}
+	created, err := p.CreateUser(in)
+	if err != nil {
+		return err
+	}
+	if l != nil {
+		l.Infof(ctx, "created user id=%s name=%s", created.ID, created.Name)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	return json.NewEncoder(w).Encode(created)
 }
 
 // handleUpdateUser updates a user for any provider.
 func (a *App) handleUpdateUser(p Provider, ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-    id := r.PathValue("id")
-    if id == "" {
-        return shttp.NewHTTPError(http.StatusBadRequest, "missing id")
-    }
-    var in User
-    if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-        return shttp.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
-    }
-    if err := p.UpdateUser(id, in); err != nil {
-        return err
-    }
-    w.WriteHeader(http.StatusNoContent)
-    return nil
+	id := shttp.PathValue(r, "id")
+	if id == "" {
+		return shttp.NewHTTPError(http.StatusBadRequest, "missing id")
+	}
+	var in User
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		return shttp.NewHTTPError(http.StatusBadRequest, "invalid JSON body")
+	}
+	if err := p.UpdateUser(id, in); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 // handleDeleteUser deletes a user for any provider.
 func (a *App) handleDeleteUser(p Provider, ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-    id := r.PathValue("id")
-    if id == "" {
-        return shttp.NewHTTPError(http.StatusBadRequest, "missing id")
-    }
-    if err := p.DeleteUser(id); err != nil {
-        return err
-    }
-    w.WriteHeader(http.StatusNoContent)
-    return nil
+	id := shttp.PathValue(r, "id")
+	if id == "" {
+		return shttp.NewHTTPError(http.StatusBadRequest, "missing id")
+	}
+	if err := p.DeleteUser(id); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 // User is a minimal user payload for the demo.
 type User struct {
-    ID    string `json:"id,omitempty"`
-    Name  string `json:"name"`
-    Email string `json:"email"`
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 type Provider interface {
-    CreateUser(user User) (*User, error)
-    DeleteUser(id string) error
-    UpdateUser(id string, user User) error
+	CreateUser(user User) (*User, error)
+	DeleteUser(id string) error
+	UpdateUser(id string, user User) error
 }
 
 // Provider1 implement Provider
@@ -166,9 +171,9 @@ type Provider1 struct{}
 func NewProvider1() *Provider1 { return &Provider1{} }
 
 func (p *Provider1) CreateUser(user User) (*User, error) {
-    // Demo implementation: assign an ID with provider prefix
-    user.ID = fmt.Sprintf("p1-%d", time.Now().UnixNano())
-    return &user, nil
+	// Demo implementation: assign an ID with provider prefix
+	user.ID = fmt.Sprintf("p1-%d", time.Now().UnixNano())
+	return &user, nil
 }
 
 func (p *Provider1) DeleteUser(id string) error { return nil }
@@ -181,8 +186,8 @@ type Provider2 struct{}
 func NewProvider2() *Provider2 { return &Provider2{} }
 
 func (p *Provider2) CreateUser(user User) (*User, error) {
-    user.ID = fmt.Sprintf("p2-%d", time.Now().UnixNano())
-    return &user, nil
+	user.ID = fmt.Sprintf("p2-%d", time.Now().UnixNano())
+	return &user, nil
 }
 
 func (p *Provider2) DeleteUser(id string) error { return nil }

--- a/examples/multi-provider/main_test.go
+++ b/examples/multi-provider/main_test.go
@@ -1,176 +1,186 @@
 package main
 
 import (
-    "bytes"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-    "github.com/andres-vara/shttp"
+	"github.com/andres-vara/shttp"
+	"github.com/andres-vara/slogr"
 )
 
 // stubProvider lets tests control Provider behavior.
 type stubProvider struct {
-    createFn func(User) (*User, error)
-    deleteFn func(string) error
-    updateFn func(string, User) error
+	createFn func(User) (*User, error)
+	deleteFn func(string) error
+	updateFn func(string, User) error
 }
 
 func (s *stubProvider) CreateUser(u User) (*User, error)   { return s.createFn(u) }
-func (s *stubProvider) DeleteUser(id string) error          { return s.deleteFn(id) }
-func (s *stubProvider) UpdateUser(id string, u User) error  { return s.updateFn(id, u) }
+func (s *stubProvider) DeleteUser(id string) error         { return s.deleteFn(id) }
+func (s *stubProvider) UpdateUser(id string, u User) error { return s.updateFn(id, u) }
 
 func TestHandleCreateUser(t *testing.T) {
-    okProvider := &stubProvider{
-        createFn: func(u User) (*User, error) {
-            u.ID = "pX-1"
-            return &u, nil
-        },
-        deleteFn: func(string) error { return nil },
-        updateFn: func(string, User) error { return nil },
-    }
+	okProvider := &stubProvider{
+		createFn: func(u User) (*User, error) {
+			u.ID = "pX-1"
+			return &u, nil
+		},
+		deleteFn: func(string) error { return nil },
+		updateFn: func(string, User) error { return nil },
+	}
 
-    app := NewApp(map[string]Provider{"ok": okProvider})
+	app := NewApp(map[string]Provider{"ok": okProvider})
 
-    tests := []struct {
-        name           string
-        provider       string
-        body           any
-        expectStatus   int
-        expectErrCode  int // if >0, expect HTTPError with that status
-    }{
-        {name: "success", provider: "ok", body: User{Name: "Ada", Email: "a@x"}, expectStatus: http.StatusCreated},
-        {name: "unknown provider", provider: "missing", body: User{Name: "Ada"}, expectErrCode: http.StatusNotFound},
-        {name: "invalid json", provider: "ok", body: "{not-json}", expectErrCode: http.StatusBadRequest},
-    }
+	tests := []struct {
+		name          string
+		provider      string
+		body          any
+		expectStatus  int
+		expectErrCode int // if >0, expect HTTPError with that status
+	}{
+		{name: "success", provider: "ok", body: User{Name: "Ada", Email: "a@x"}, expectStatus: http.StatusCreated},
+		{name: "unknown provider", provider: "missing", body: User{Name: "Ada"}, expectErrCode: http.StatusNotFound},
+		{name: "invalid json", provider: "ok", body: "{not-json}", expectErrCode: http.StatusBadRequest},
+	}
 
-    for _, tc := range tests {
-        t.Run(tc.name, func(t *testing.T) {
-            var bodyBytes []byte
-            switch v := tc.body.(type) {
-            case string:
-                bodyBytes = []byte(v)
-            default:
-                b, _ := json.Marshal(v)
-                bodyBytes = b
-            }
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var bodyBytes []byte
+			switch v := tc.body.(type) {
+			case string:
+				bodyBytes = []byte(v)
+			default:
+				b, _ := json.Marshal(v)
+				bodyBytes = b
+			}
 
-            req := httptest.NewRequest(http.MethodPost, "/providers/"+tc.provider+"/users", bytes.NewReader(bodyBytes))
-            w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/providers/"+tc.provider+"/users", bytes.NewReader(bodyBytes))
+			// Simulate router path parameter resolution
+			req = shttp.SetPathValue(req, "provider", tc.provider)
+			w := httptest.NewRecorder()
 
-            handler := app.withProvider(app.handleCreateUser)
-            err := handler(req.Context(), w, req)
+			handler := app.withProvider(app.handleCreateUser)
+			// Inject a request-scoped logger into context via middleware
+			testLogger := slogr.New(io.Discard, slogr.DefaultOptions())
+			handlerWithLogger := shttp.ContextualLogger(testLogger)(handler)
+			err := handlerWithLogger(req.Context(), w, req)
 
-            if tc.expectErrCode > 0 {
-                if err == nil {
-                    t.Fatalf("expected error %d, got nil", tc.expectErrCode)
-                }
-                if httpErr, ok := err.(shttp.HTTPError); !ok || httpErr.StatusCode != tc.expectErrCode {
-                    t.Fatalf("expected HTTPError(%d), got %#v", tc.expectErrCode, err)
-                }
-                return
-            }
+			if tc.expectErrCode > 0 {
+				if err == nil {
+					t.Fatalf("expected error %d, got nil", tc.expectErrCode)
+				}
+				if httpErr, ok := err.(shttp.HTTPError); !ok || httpErr.StatusCode != tc.expectErrCode {
+					t.Fatalf("expected HTTPError(%d), got %#v", tc.expectErrCode, err)
+				}
+				return
+			}
 
-            if err != nil {
-                t.Fatalf("unexpected error: %v", err)
-            }
-            if w.Code != tc.expectStatus {
-                t.Fatalf("status %d, want %d", w.Code, tc.expectStatus)
-            }
-            // Basic JSON shape check
-            var got User
-            if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
-                t.Fatalf("invalid json: %v", err)
-            }
-            if got.ID == "" || got.Name == "" {
-                t.Fatalf("unexpected body: %+v", got)
-            }
-        })
-    }
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if w.Code != tc.expectStatus {
+				t.Fatalf("status %d, want %d", w.Code, tc.expectStatus)
+			}
+			// Basic JSON shape check
+			var got User
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("invalid json: %v", err)
+			}
+			if got.ID == "" || got.Name == "" {
+				t.Fatalf("unexpected body: %+v", got)
+			}
+		})
+	}
 }
 
 func TestHandleUpdateUser(t *testing.T) {
-    called := false
-    okProvider := &stubProvider{
-        createFn: func(u User) (*User, error) { return &u, nil },
-        deleteFn: func(string) error { return nil },
-        updateFn: func(id string, u User) error { called = true; return nil },
-    }
-    app := NewApp(map[string]Provider{"ok": okProvider})
+	called := false
+	okProvider := &stubProvider{
+		createFn: func(u User) (*User, error) { return &u, nil },
+		deleteFn: func(string) error { return nil },
+		updateFn: func(id string, u User) error { called = true; return nil },
+	}
+	app := NewApp(map[string]Provider{"ok": okProvider})
 
-    t.Run("success", func(t *testing.T) {
-        body, _ := json.Marshal(User{Name: "Ada"})
-        req := httptest.NewRequest(http.MethodPut, "/providers/ok/users/123", bytes.NewReader(body))
-        req.SetPathValue("id", "123")
-        w := httptest.NewRecorder()
+	t.Run("success", func(t *testing.T) {
+		body, _ := json.Marshal(User{Name: "Ada"})
+		req := httptest.NewRequest(http.MethodPut, "/providers/ok/users/123", bytes.NewReader(body))
+		req = shttp.SetPathValue(req, "provider", "ok")
+		req = shttp.SetPathValue(req, "id", "123")
+		w := httptest.NewRecorder()
 
-        handler := app.withProvider(app.handleUpdateUser)
-        if err := handler(req.Context(), w, req); err != nil {
-            t.Fatalf("unexpected error: %v", err)
-        }
-        if w.Code != http.StatusNoContent {
-            t.Fatalf("status %d, want %d", w.Code, http.StatusNoContent)
-        }
-        if !called {
-            t.Fatalf("provider.UpdateUser was not called")
-        }
-    })
+		handler := app.withProvider(app.handleUpdateUser)
+		if err := handler(req.Context(), w, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status %d, want %d", w.Code, http.StatusNoContent)
+		}
+		if !called {
+			t.Fatalf("provider.UpdateUser was not called")
+		}
+	})
 
-    t.Run("missing id", func(t *testing.T) {
-        body, _ := json.Marshal(User{Name: "Ada"})
-        req := httptest.NewRequest(http.MethodPut, "/providers/ok/users/", bytes.NewReader(body))
-        w := httptest.NewRecorder()
-        handler := app.withProvider(app.handleUpdateUser)
-        err := handler(req.Context(), w, req)
-        if err == nil {
-            t.Fatalf("expected error, got nil")
-        }
-        if httpErr, ok := err.(shttp.HTTPError); !ok || httpErr.StatusCode != http.StatusBadRequest {
-            t.Fatalf("expected HTTPError(400), got %#v", err)
-        }
-    })
+	t.Run("missing id", func(t *testing.T) {
+		body, _ := json.Marshal(User{Name: "Ada"})
+		req := httptest.NewRequest(http.MethodPut, "/providers/ok/users/", bytes.NewReader(body))
+		req = shttp.SetPathValue(req, "provider", "ok")
+		w := httptest.NewRecorder()
+		handler := app.withProvider(app.handleUpdateUser)
+		err := handler(req.Context(), w, req)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if httpErr, ok := err.(shttp.HTTPError); !ok || httpErr.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected HTTPError(400), got %#v", err)
+		}
+	})
 }
 
 func TestHandleDeleteUser(t *testing.T) {
-    called := false
-    okProvider := &stubProvider{
-        createFn: func(u User) (*User, error) { return &u, nil },
-        deleteFn: func(id string) error { called = true; return nil },
-        updateFn: func(string, User) error { return nil },
-    }
-    app := NewApp(map[string]Provider{"ok": okProvider})
+	called := false
+	okProvider := &stubProvider{
+		createFn: func(u User) (*User, error) { return &u, nil },
+		deleteFn: func(id string) error { called = true; return nil },
+		updateFn: func(string, User) error { return nil },
+	}
+	app := NewApp(map[string]Provider{"ok": okProvider})
 
-    t.Run("success", func(t *testing.T) {
-        req := httptest.NewRequest(http.MethodDelete, "/providers/ok/users/abc", nil)
-        req.SetPathValue("id", "abc")
-        w := httptest.NewRecorder()
+	t.Run("success", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/providers/ok/users/abc", nil)
+		req = shttp.SetPathValue(req, "provider", "ok")
+		req = shttp.SetPathValue(req, "id", "abc")
+		w := httptest.NewRecorder()
 
-        handler := app.withProvider(app.handleDeleteUser)
-        if err := handler(req.Context(), w, req); err != nil {
-            t.Fatalf("unexpected error: %v", err)
-        }
-        if w.Code != http.StatusNoContent {
-            t.Fatalf("status %d, want %d", w.Code, http.StatusNoContent)
-        }
-        if !called {
-            t.Fatalf("provider.DeleteUser was not called")
-        }
-    })
+		handler := app.withProvider(app.handleDeleteUser)
+		if err := handler(req.Context(), w, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status %d, want %d", w.Code, http.StatusNoContent)
+		}
+		if !called {
+			t.Fatalf("provider.DeleteUser was not called")
+		}
+	})
 
-    t.Run("unknown provider", func(t *testing.T) {
-        req := httptest.NewRequest(http.MethodDelete, "/providers/missing/users/abc", nil)
-        req.SetPathValue("id", "abc")
-        w := httptest.NewRecorder()
+	t.Run("unknown provider", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/providers/missing/users/abc", nil)
+		req = shttp.SetPathValue(req, "provider", "missing")
+		req = shttp.SetPathValue(req, "id", "abc")
+		w := httptest.NewRecorder()
 
-        handler := app.withProvider(app.handleDeleteUser)
-        err := handler(req.Context(), w, req)
-        if err == nil {
-            t.Fatalf("expected error, got nil")
-        }
-        if httpErr, ok := err.(shttp.HTTPError); !ok || httpErr.StatusCode != http.StatusNotFound {
-            t.Fatalf("expected HTTPError(404), got %#v", err)
-        }
-    })
+		handler := app.withProvider(app.handleDeleteUser)
+		err := handler(req.Context(), w, req)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if httpErr, ok := err.(shttp.HTTPError); !ok || httpErr.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected HTTPError(404), got %#v", err)
+		}
+	})
 }
-

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -27,4 +27,4 @@ func main() {
 	if err := server.Start(); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}
-} 
+}

--- a/examples/simple_logger/main.go
+++ b/examples/simple_logger/main.go
@@ -35,13 +35,13 @@ func main() {
 		// Try to get logger from context
 		ctx := r.Context()
 		loggerFromCtx := GetLogger(ctx)
-		
+
 		if loggerFromCtx == nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintln(w, "Logger not found in context")
 			return
 		}
-		
+
 		// Logger was found!
 		loggerFromCtx.Info(ctx, "Handler called with logger from context")
 		w.WriteHeader(http.StatusOK)
@@ -50,21 +50,21 @@ func main() {
 
 	// Wrap our handler in middleware
 	originalHandler := http.DefaultServeMux
-	
+
 	// Create middleware handler that adds logger to context
 	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Add logger to context
 		ctx := context.WithValue(r.Context(), loggerKey, logger)
-		
+
 		// Call the next handler with updated context
 		originalHandler.ServeHTTP(w, r.WithContext(ctx))
 	})
 
 	// Log startup
 	logger.Info(context.Background(), "Server starting on :8080")
-	
+
 	// Start server
 	if err := http.ListenAndServe(":8080", wrappedHandler); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}
-} 
+}

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -142,4 +142,4 @@ func generateSelfSignedCert() (string, string, error) {
 	keyOut.Close()
 
 	return certFile, keyFile, nil
-} 
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,6 @@ module github.com/andres-vara/shttp
 go 1.24.0
 
 require github.com/andres-vara/slogr v0.0.3
+
+// Use local copy of slogr during development
+replace github.com/andres-vara/slogr => ../slogr

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,60 @@
+package shttp
+
+import (
+    "context"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/andres-vara/slogr"
+)
+
+// TestIntegration_ServerWithMiddleware starts an httptest.Server using the
+// package router and exercises middleware + path param extraction end-to-end.
+func TestIntegration_ServerWithMiddleware(t *testing.T) {
+    ctx := context.Background()
+
+    logger := slogr.New(io.Discard, slogr.DefaultOptions())
+    cfg := &Config{Addr: ":0", Logger: logger}
+    srv := New(ctx, cfg)
+
+    // Register middleware in the expected order
+    srv.Use(
+        RequestIDMiddleware(),
+        ContextualLogger(logger),
+        LoggerMiddleware(logger),
+        LoggingMiddleware(logger),
+        RecoveryMiddleware(logger),
+    )
+
+    // Simple handler that returns the path parameter value
+    srv.GET("/hello/{name}", func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+        name := PathValue(r, "name")
+        w.WriteHeader(http.StatusOK)
+        _, _ = w.Write([]byte(name))
+        return nil
+    })
+
+    ts := httptest.NewServer(srv.Router())
+    defer ts.Close()
+
+    res, err := http.Get(ts.URL + "/hello/alice")
+    if err != nil {
+        t.Fatalf("request failed: %v", err)
+    }
+    defer res.Body.Close()
+
+    if res.StatusCode != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", res.StatusCode)
+    }
+
+    body, _ := io.ReadAll(res.Body)
+    if string(body) != "alice" {
+        t.Fatalf("unexpected body: %q", string(body))
+    }
+
+    if res.Header.Get("X-Request-ID") == "" {
+        t.Fatalf("expected X-Request-ID header set by RequestIDMiddleware")
+    }
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -70,7 +70,7 @@ func TestRequestIDMiddleware(t *testing.T) {
 			},
 		},
 		{
-			name:           "Adds client IP to context",
+			name: "Adds client IP to context",
 			handler: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 				// Extract the client IP from the context
 				clientIP := GetClientIP(ctx)
@@ -170,18 +170,18 @@ func TestLoggerMiddleware(t *testing.T) {
 	var logOutput strings.Builder
 
 	logger := slogr.New(&logOutput, &slogr.Options{
-		Level: slog.LevelDebug,
+		Level:       slog.LevelDebug,
 		HandlerType: slogr.HandlerTypeJSON,
 	})
 
 	tests := []struct {
-		name           string
-		handler        Handler
-		wantStatusCode int
+		name            string
+		handler         Handler
+		wantStatusCode  int
 		wantLogContains string
 	}{
 		{
-			name:           "Adds logger to context",
+			name: "Adds logger to context",
 			handler: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 				// Get the logger from context and log something
 				if ctxLogger, ok := ctx.Value(LoggerKey).(*slogr.Logger); ok && ctxLogger != nil {
@@ -191,7 +191,7 @@ func TestLoggerMiddleware(t *testing.T) {
 				}
 				return fmt.Errorf("logger not found in context")
 			},
-			wantStatusCode: http.StatusOK,
+			wantStatusCode:  http.StatusOK,
 			wantLogContains: "Test log from handler",
 		},
 	}
@@ -227,11 +227,11 @@ func TestLoggingMiddleware(t *testing.T) {
 	logger := slogr.New(&logOutput, slogr.DefaultOptions())
 
 	tests := []struct {
-		name              string
-		setupContext      func(context.Context) context.Context
-		handler           Handler
-		wantStatusCode    int
-		wantLogContains   []string
+		name               string
+		setupContext       func(context.Context) context.Context
+		handler            Handler
+		wantStatusCode     int
+		wantLogContains    []string
 		wantLogNotContains []string
 	}{
 		{
@@ -242,7 +242,7 @@ func TestLoggingMiddleware(t *testing.T) {
 				ctx = context.WithValue(ctx, ClientIPKey, "127.0.0.1")
 				return ctx
 			},
-			handler: simpleHandler("success"),
+			handler:        simpleHandler("success"),
 			wantStatusCode: http.StatusOK,
 			wantLogContains: []string{
 				"[http.request]",
@@ -266,7 +266,7 @@ func TestLoggingMiddleware(t *testing.T) {
 				ctx = context.WithValue(ctx, ClientIPKey, "127.0.0.1")
 				return ctx
 			},
-			handler: errorHandler("test error"),
+			handler:        errorHandler("test error"),
 			wantStatusCode: http.StatusInternalServerError,
 			wantLogContains: []string{
 				"[http.request]",
@@ -327,10 +327,10 @@ func TestRecoveryMiddleware(t *testing.T) {
 	logger := slogr.New(&logOutput, slogr.DefaultOptions())
 
 	tests := []struct {
-		name           string
-		setupContext   func(context.Context) context.Context
-		handler        Handler
-		wantStatusCode int
+		name            string
+		setupContext    func(context.Context) context.Context
+		handler         Handler
+		wantStatusCode  int
 		wantLogContains []string
 	}{
 		{
@@ -357,8 +357,8 @@ func TestRecoveryMiddleware(t *testing.T) {
 			setupContext: func(ctx context.Context) context.Context {
 				return ctx
 			},
-			handler: simpleHandler("normal"),
-			wantStatusCode: http.StatusOK,
+			handler:         simpleHandler("normal"),
+			wantStatusCode:  http.StatusOK,
 			wantLogContains: []string{},
 		},
 	}

--- a/pathparams.go
+++ b/pathparams.go
@@ -1,0 +1,68 @@
+package shttp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// pathParamsKey is the context key used to store path parameters.
+type pathParamsKey struct{}
+
+// SetPathValues returns a new *http.Request whose context contains the provided params map.
+func SetPathValues(r *http.Request, params map[string]string) *http.Request {
+	if params == nil {
+		return r
+	}
+	ctx := context.WithValue(r.Context(), pathParamsKey{}, params)
+	return r.WithContext(ctx)
+}
+
+// SetPathValue sets a single path parameter on the request and returns the updated request.
+// It merges with any existing param map.
+func SetPathValue(r *http.Request, key, value string) *http.Request {
+	var params map[string]string
+	if existing, ok := r.Context().Value(pathParamsKey{}).(map[string]string); ok && existing != nil {
+		// copy to avoid mutating original map
+		params = make(map[string]string, len(existing)+1)
+		for k, v := range existing {
+			params[k] = v
+		}
+	} else {
+		params = make(map[string]string)
+	}
+	params[key] = value
+	return SetPathValues(r, params)
+}
+
+// PathValue retrieves a path parameter value from the request. Returns empty string if not found.
+func PathValue(r *http.Request, key string) string {
+	if params, ok := r.Context().Value(pathParamsKey{}).(map[string]string); ok && params != nil {
+		return params[key]
+	}
+	return ""
+}
+
+// extractPathParams extracts named parameters from a registered pattern and an actual path.
+// Example: pattern "/users/{id}" and path "/users/123" -> map[id]="123"
+func extractPathParams(pattern, path string) map[string]string {
+	// Normalize leading/trailing slashes then split
+	pSegs := strings.Split(strings.Trim(pattern, "/"), "/")
+	aSegs := strings.Split(strings.Trim(path, "/"), "/")
+
+	if len(pSegs) != len(aSegs) {
+		// If lengths differ, we still try to match trailing empty segment cases
+		return nil
+	}
+
+	params := make(map[string]string)
+	for i := 0; i < len(pSegs); i++ {
+		ps := pSegs[i]
+		if strings.HasPrefix(ps, "{") && strings.HasSuffix(ps, "}") {
+			key := strings.TrimSuffix(strings.TrimPrefix(ps, "{"), "}")
+			params[key] = aSegs[i]
+		}
+	}
+
+	return params
+}

--- a/router_test.go
+++ b/router_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/andres-vara/slogr"
 )
 
-
 func TestServerRouting(t *testing.T) {
 	// Test cases for HTTP method registration
 	tests := []struct {
@@ -45,7 +44,7 @@ func TestServerRouting(t *testing.T) {
 			path:   "/test/{param1}",
 			setupServer: func(s *Server) {
 				s.GET("/test/{param1}", func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-					param1 := r.PathValue("param1")
+					param1 := PathValue(r, "param1")
 					w.Write([]byte(param1))
 					return nil
 				})
@@ -193,5 +192,3 @@ func TestServerRouting(t *testing.T) {
 		})
 	}
 }
-
-

--- a/server_test.go
+++ b/server_test.go
@@ -65,7 +65,6 @@ func TestNew(t *testing.T) {
 	}
 }
 
-
 func TestRouterMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -191,4 +190,4 @@ func TestRouterMiddleware(t *testing.T) {
 			}
 		})
 	}
-} 
+}


### PR DESCRIPTION
Title: router: add path-params extraction; middleware improvements

Description:
This PR implements minimal path-parameter extraction without adding third-party dependencies, and improves middleware logging and API compatibility.

Changes included:
- Add shttp/pathparams.go with helpers: SetPathValues, SetPathValue, PathValue, extractPathParams.
- Update shttp/router.go to inject path params into the request context for route patterns using {param}.
- Add LoggerMiddleware(logger) and update LoggingMiddleware(logger) to accept an optional logger and emit structured [http.request] / [http.response] logs including request_id, user_id, client_ip, status, duration_ms, and error when present.
- Update tests and examples to use the new helpers.
- Add GitHub Actions workflow .github/workflows/ci.yml to run tests for both slogr and shttp modules on push and PRs.

Notes:
- Path extraction uses simple segment-by-segment matching; named tokens must be full path segments (for example /users/{id}). No wildcard/regex support yet to keep the implementation small and dependency-free.
- Tests: ran go test ./... -v locally; all tests passed.

Follow-ups:
- Extend path pattern support if desired (wildcards/optional segments).
- Add a short README usage example showing PathValue usage.
- Add an integration test that starts the server on port 0 to exercise middleware end-to-end.
