### PR TITLE
docs: cleanup README, add release job, and fix CI auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get latest tag
         id: latest_tag
@@ -90,6 +91,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=${{ steps.next_version.outputs.version }}
+          git config --global credential.helper store
+          echo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com" > ~/.git-credentials
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$VERSION" -m "Release $VERSION"


### PR DESCRIPTION
This PR includes:

- Cleaned README (removed stray code at top)
- Added release job that auto-creates tags and releases on merge to main
- Fixed git authentication for release job using GITHUB_TOKEN
- Includes expanded docs in docs/ folder and site index

CI will run all tests before allowing merge per branch protection rules.